### PR TITLE
Fixed glow not appearing and fixed some issues.

### DIFF
--- a/sourcemod/scripting/bot-control.sp
+++ b/sourcemod/scripting/bot-control.sp
@@ -628,10 +628,9 @@ public Action SentryVision_OnThink(int iSentryGlow, int iClient)
 	}
 	else //I don't have any parent, how de fuk is glow still alive? Safe check, kill.
 		AcceptEntityInput(iSentryGlow, "Kill");
-	/*
+
 	if (0 < iClient <= MaxClients && IsClientInGame(iClient) && g_bIsSentryBuster[iClient]) return Plugin_Continue;//Allow the sentry buster to see the glow.
 	return Plugin_Handled;//Do not allow other players to see it.
-	*/
 }
 
 public void OnSpawnPost(int trigger)

--- a/sourcemod/scripting/bot-control.sp
+++ b/sourcemod/scripting/bot-control.sp
@@ -307,7 +307,7 @@ public void OnPluginStart()
 	HookEvent("teamplay_round_start", Event_ResetBots);
 	HookEvent("mvm_wave_complete",    Event_ResetBots);
 	HookEvent("player_sapped_object", Event_SappedObject);
-
+	
 	RegConsoleCmd("sm_joinblue",   Command_ToggleRandomPicker);
 	RegConsoleCmd("sm_joinblu",    Command_ToggleRandomPicker);
 	RegConsoleCmd("sm_joinbrobot", Command_ToggleRandomPicker);
@@ -513,10 +513,6 @@ public void OnEntityCreated(int entity, const char[] classname)
 		SDKHook(entity, SDKHook_SetTransmit, Hook_TeleporterTransmit);
 		SDKHook(entity, SDKHook_OnTakeDamage, Hook_TeleporterTakeDamage);
 	}
-	else if(StrEqual(classname, "obj_sentrygun"))
-	{
-		RequestFrame(Frame_SentryVision_Create, EntIndexToEntRef(entity));
-	}
 	
 	if(g_bIsMannhattan)
 	{
@@ -569,26 +565,54 @@ public Action SentryVision_OnThink(int iSentryGlow, int iClient)
 	int iParent = GetEntPropEnt(iSentryGlow, Prop_Send, "moveparent");
 	if (iParent > MaxClients)//Safe check to know if I'm parented to the sentry and NOT carried! We don't want to put the glow on the blueprint!
 	{
-		bool bCarried = (GetEntProp(iSentryGlow, Prop_Send, "m_bCarried") || GetEntProp(iSentryGlow, Prop_Send, "m_bPlacing"));
-		if (bCarried)//I'm parented, set my parent to the engie!
-			iParent = GetEntPropEnt(iSentryGlow, Prop_Send, "m_hOwnerEntity");
+		bool bCarried = (GetEntProp(iParent, Prop_Send, "m_bCarried") || GetEntProp(iParent, Prop_Send, "m_bPlacing"));
+		if (bCarried)//The sentry is carried, set my parent to the engie!
+			iParent = GetEntPropEnt(iParent, Prop_Send, "m_hBuilder");
 	}
+	else if (0 < iParent <= MaxClients)//My parent is the engie.
+	{
+		static int iRefCarriedObjects[MAXPLAYERS+1];//Last carried object by the engie.
+		
+		bool bCarrying = view_as<bool>(GetEntProp(iParent, Prop_Send, "m_bCarryingObject"));
+		if (bCarrying)
+		{
+			int iCarriedObject = GetEntPropEnt(iParent, Prop_Send, "m_hCarriedObject");
+			if (iCarriedObject > MaxClients)
+				iRefCarriedObjects[iParent] = EntIndexToEntRef(iCarriedObject);//Save the building's index object, very important so we don't blindy loop across every sentry guns once it's placed, and end up setting 2 glows on the same sentry (i.e 2 glows on an engie's mini-sentry)
+			else
+				AcceptEntityInput(iSentryGlow, "Kill");
+		}
+		else //The sentry is no longer carried but I'm still parented to the player, move my parent to the sentry.
+		{
+			int iSentry = EntRefToEntIndex(iRefCarriedObjects[iParent]);
+			if (iSentry > MaxClients)
+				iParent = iSentry;
+			else //The sentry has been destroyed, kill our glow
+				AcceptEntityInput(iSentryGlow,"Kill");
+		}
+	}
+	
 	//Keep my model and parent infos up to date.
 	if (0 < iParent <= MaxClients || iParent > MaxClients)
 	{
+		int iOldParent = GetEntPropEnt(iSentryGlow, Prop_Send, "moveparent");
+		
+		if (iParent != iOldParent)
+		{
+			//Unparent me from my old parent.
+			AcceptEntityInput(iSentryGlow,"ClearParent");
+			
+			float flParentPos[3];
+			GetEntPropVector(iParent, Prop_Data, "m_vecAbsOrigin", flParentPos);
+			TeleportEntity(iSentryGlow, flParentPos, NULL_VECTOR, NULL_VECTOR);
+			
+			//Parent me to the new entity.
+			SetVariantString("!activator");
+			AcceptEntityInput(iSentryGlow, "SetParent", iParent);
+		}
+		
 		if (GetEntProp(iSentryGlow, Prop_Send, "m_nModelIndex") != GetEntProp(iParent, Prop_Send, "m_nModelIndex"))
 		{
-			int iOldParent = GetEntPropEnt(iSentryGlow, Prop_Send, "moveparent");
-			
-			if (iParent != iOldParent)
-			{
-				//Unparent me from my old parent.
-				AcceptEntityInput(iSentryGlow,"ClearParent");
-				//Parent me to the new entity.
-				SetVariantString("!activator");
-				AcceptEntityInput(iSentryGlow, "SetParent", iParent);
-			}
-			
 			//Update my model.
 			char strModelSentry[PLATFORM_MAX_PATH];
 			GetEntPropString(iParent, Prop_Data, "m_ModelName", strModelSentry, sizeof(strModelSentry));
@@ -604,8 +628,10 @@ public Action SentryVision_OnThink(int iSentryGlow, int iClient)
 	}
 	else //I don't have any parent, how de fuk is glow still alive? Safe check, kill.
 		AcceptEntityInput(iSentryGlow, "Kill");
+	/*
 	if (0 < iClient <= MaxClients && IsClientInGame(iClient) && g_bIsSentryBuster[iClient]) return Plugin_Continue;//Allow the sentry buster to see the glow.
 	return Plugin_Handled;//Do not allow other players to see it.
+	*/
 }
 
 public void OnSpawnPost(int trigger)
@@ -1451,6 +1477,17 @@ public Action Event_BuildObject(Event event, const char[] name, bool dontBroadca
 		else
 		{
 			DispatchKeyValue(iEnt, "defaultupgrade", "2");
+		}
+	}
+	
+	if (IsClientInGame(client) && TF2_GetPlayerClass(client) == TFClass_Engineer && TF2_GetClientTeam(client) == TFTeam_Red)
+	{
+		TFObjectType TFObject = view_as<TFObjectType>(event.GetInt("object"));
+		
+		if (TFObject == TFObject_Sentry)
+		{
+			int iEnt = event.GetInt("index");
+			RequestFrame(Frame_SentryVision_Create, EntIndexToEntRef(iEnt));
 		}
 	}
 	


### PR DESCRIPTION
* Moved the glow creation under the build object event (some netprops on
the sentry and the player doesn't get initialized until the sentry is
built at least once).
* Fixed an issue where the sentry owner couldn't be retrived.

Everything should be fine from now .

I couldn't test the code yesterday, but I did today, and everything is working fine.
And here some screenies:
[the sentry is being placed for the 1st time](http://images.akamai.steamusercontent.com/ugc/183919804163871707/B1B5B8D32B288D5C18B7896DA12045E6333E33C0/)
[the sentry has been placed](http://images.akamai.steamusercontent.com/ugc/183919804163872773/84F02051BCCC50B4DAD7D58D8F2F7842836CD8D2/)
[the sentry has been placed, and now it's now carried](http://images.akamai.steamusercontent.com/ugc/183919804163874152/3AB5D887E34926FF53CA6E0292842BD3FD90E61D/)
[placing a mini sentry for the 1st time, while the main sentry is built](http://images.akamai.steamusercontent.com/ugc/183919804163887608/1B48BDEC9DF97E02C9519BD01A5A21377D00A511/)
[the mini has been placed](http://images.akamai.steamusercontent.com/ugc/183919804163888645/32AB4388834A796EC9CCA9C4ADB65E4E23001F32/)
[carrying a mini sentry that has been placed, while the main sentry is built](http://images.akamai.steamusercontent.com/ugc/183919804163915384/D069A46AEB8BB97C45F9F6F5EC0E2175C0789D68/)
[final screenshot, showing the glow is reapplied fine to the mini sentry, and not to the main sentry](http://images.akamai.steamusercontent.com/ugc/183919804163916464/9A023EA467D70D41F396FB9E79BC4B13ADCF7BAB/)

That pull request should also fix issue #6, I couldn't test it, but according to valve's code, it looks if the bot was either killed by a sniper holding a bow/sniper, or look for the attribute "force_distribute_currency_on_death", but those attributes with "_", can't be hooked by TF2Attributes, hopefully I only saw that attribute being applied to bots only so far, so I don't think there's any point to worry about that attribute.

